### PR TITLE
bugfix: Added page number to cover page

### DIFF
--- a/canflood/results/reporter.py
+++ b/canflood/results/reporter.py
@@ -210,6 +210,11 @@ class ReportGenerator(RiskPlotr, Qcoms):
         t = 'report generated on %s'%self.today_str
         self.add_label(qlayout=report_header, text=t,
                        qrect=QRectF(5, 55, 200, 50))
+
+        #=======================================================================
+        # add the page number
+        #=======================================================================
+        self.add_page_number(qlayout=report_header)     
         
         
         log.debug('set header from template file: %s'%template_fp)


### PR DESCRIPTION
# CanFlood

## Changelog:

- Added a call to the add page function when creating report header from layout

## Test coverage for this change:

- [ ] I have added API unit tests
- [ ] I have added appropriate UI unit tests (ng component or cypress)
- [X] I have not added tests

## Additional Notes:
Could have been accomplished by altering the layout template but would rather be consistent and use paging function