### PR TITLE
feature: Changed page header text to use name from control file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 ## Test coverage for this change:
 
 - [ ] I have added API unit tests
-- [ ] I have added appropriate UI unit tests (ng component or cypress)
+- [ ] I have added appropriate UI unit tests
 - [ ] I have not added tests
 
 ## Additional Notes:

--- a/canflood/model/riskcom.py
+++ b/canflood/model/riskcom.py
@@ -286,10 +286,7 @@ class RiskModel(Plotr, Model): #common methods for risk1 and risk2
         df1 = tlRaw_df.copy()
         
         """
-        TODO: harmonize this with 'impact_units' loaded from control file
-            generally set (in cf) by model.dmg2.Dmg2.run(set_impactUnits=True)
-            or read from control file
-            then written to r_ttl 
+        taking the value from 'impact_units' loaded from control file
         """
         self.impact_name = self.impact_units #get the label for the impacts
         

--- a/canflood/results/reporter.py
+++ b/canflood/results/reporter.py
@@ -236,7 +236,7 @@ class ReportGenerator(RiskPlotr, Qcoms):
         self.add_page_number(qlayout=body)
 
         #add page header to section
-        self.add_page_header(qlayout=body)
+        self.add_page_header(qlayout=body, text=self.name)
                 
         #change the page size
         page_collection = body.pageCollection()


### PR DESCRIPTION
# CanFlood

## Changelog:

- Switched to using name from control file as header text
- Fixed comment on impact_name variable

## Test coverage for this change:

- [ ] I have added API unit tests
- [ ] I have added appropriate UI unit tests
- [X] I have not added tests

## Additional Notes: