### PR TITLE
feature: Adding Event summary table underneath diagrams

### DIFF
--- a/canflood/results/dialog.py
+++ b/canflood/results/dialog.py
@@ -817,7 +817,7 @@ class ResultsDialog(QtWidgets.QDialog, FORM_CLASS, hlpr.plug.QprojPlug):
             
             # add the total plots
             for name, fp in plots_d.items():
-                wrkr.add_picture(fp=fp, df=r_ttl_df[['aep', 'impacts']])
+                wrkr.add_picture(fp=fp, df=r_ttl_df.iloc[:, 0:2])
             self.feedback.setProgress(50)
             
             

--- a/canflood/results/dialog.py
+++ b/canflood/results/dialog.py
@@ -544,27 +544,31 @@ class ResultsDialog(QtWidgets.QDialog, FORM_CLASS, hlpr.plug.QprojPlug):
         # get finv from control file
         #=======================================================================
         kwargs = {attn:getattr(self, attn) for attn in self.inherit_fieldNames}
-        #wrkr = results.riskPlot.RiskPlotr(**kwargs).setup()
         
         with Model(**kwargs) as wrkr:
             #load the control file
             wrkr.init_model(check_pars=False)
             
-            #load data from teh control file
+            #load data from the control file
             dtag_d = {k:d for k,d in wrkr.dtag_d.items() if k=='finv'}
             wrkr.load_df_ctrl(dtag_d=dtag_d)
             df_raw = wrkr.raw_d.pop('finv')
+
+        return df_raw
+
+    def get_r_ttl(self):
+        self._set_setup(set_cf_fp=True)
+
+        #=======================================================================
+        # get r_ttl from control file
+        #=======================================================================
+        kwargs = {attn:getattr(self, attn) for attn in self.inherit_fieldNames}
+
+        with Model(**kwargs) as wrkr:
+            wrkr.init_model(check_pars=False)
+
+            df_raw = pd.read_csv(wrkr.r_ttl)
             
-
-#===============================================================================
-#         finv_fp = wrkr.finv
-# 
-#         assert os.path.exists(finv_fp), 'passed invalid finv file path: %s'%finv_fp
-#         df_raw = pd.read_csv(finv_fp, index_col=0)
-#===============================================================================
-        
-        #df = df_raw.head(10)
-
         return df_raw
 
     def run_compare(self):
@@ -781,6 +785,9 @@ class ResultsDialog(QtWidgets.QDialog, FORM_CLASS, hlpr.plug.QprojPlug):
 
         finv_df = self.get_finv() #retrieve the inventory frame
         assert isinstance(finv_df, pd.DataFrame), 'failed to load finv'
+
+        r_ttl_df = self.get_r_ttl() #retrieve the event summary table
+        assert isinstance(r_ttl_df, pd.DataFrame), 'failed to load r_ttl'
         #=======================================================================
         # init
         #=======================================================================  
@@ -810,7 +817,7 @@ class ResultsDialog(QtWidgets.QDialog, FORM_CLASS, hlpr.plug.QprojPlug):
             
             # add the total plots
             for name, fp in plots_d.items():
-                wrkr.add_picture(fp)
+                wrkr.add_picture(fp=fp, df=r_ttl_df[['aep', 'impacts']])
             self.feedback.setProgress(50)
             
             

--- a/canflood/results/reporter.py
+++ b/canflood/results/reporter.py
@@ -453,8 +453,11 @@ class ReportGenerator(RiskPlotr, Qcoms):
 
         # Check that event summary table is present
         if df is not None:
+            #format table
             df.columns = map(str.upper, df.columns)
-            df.loc[:, 'IMPACTS'] = df['IMPACTS'].map(lambda impact_val: self.impactFmtFunc(impact_val))
+            df.iloc[:, 1] = df.iloc[:, 1].map(lambda impact_val: self.impactFmtFunc(impact_val))
+            
+            #convert to layer
             df_layer = self.vlay_new_df2(df, layname='event_summary_table',
                                        logger=log)
             # Add table header

--- a/canflood/results/reporter.py
+++ b/canflood/results/reporter.py
@@ -350,6 +350,7 @@ class ReportGenerator(RiskPlotr, Qcoms):
                   qrect=QRectF(5, 20, 200, 10),
                   text_size=8,
                   text_bold=True,
+                  text_underline=False,
                   **kwargs):
         
         #=======================================================================
@@ -369,6 +370,7 @@ class ReportGenerator(RiskPlotr, Qcoms):
         font = QtGui.QFont()
         font.setPointSize(text_size)
         font.setBold(text_bold)
+        font.setUnderline(text_underline)
         label.setFont(font)
         
         qlayout.addLayoutItem(label)
@@ -451,14 +453,16 @@ class ReportGenerator(RiskPlotr, Qcoms):
 
         # Check that event summary table is present
         if df is not None:
-            df_layer = self.vlay_new_df2(df.reset_index(), layname='event_summary_table',
+            df.columns = map(str.upper, df.columns)
+            df.loc[:, 'IMPACTS'] = df['IMPACTS'].map(lambda impact_val: self.impactFmtFunc(impact_val))
+            df_layer = self.vlay_new_df2(df, layname='event_summary_table',
                                        logger=log)
             # Add table header
             self.add_label(qlayout=qlayout, text='Event Summary Table', qrect=QRectF(5, 145, 100, 100), 
-                                                                            text_size=16, text_bold=False)
+                                                                            text_size=16, text_bold=False, text_underline=True)
             # Add the table under the picture                       
             self.add_table(df_layer, qlayout=qlayout, 
-                            qrect=QRectF(25, 160, 160, 49.050), column_width=50)
+                            qrect=QRectF(25, 160, 160, 49.050), column_width=34)
         
         log.debug('added item from %s'%fp)
         


### PR DESCRIPTION
# CanFlood

## Changelog:

- Added condition to add_picture method to add table if dataframe is present
- Added optional dataframe param to add_picture method
- Added new method in dialog.py to fetch r_ttl and load csv as dataframe
- Displaying event summary table underneath plots in report 

## Test coverage for this change:

- [ ] I have added API unit tests
- [ ] I have added appropriate UI unit tests
- [X] I have not added tests

## Additional Notes: