### PR TITLE
107 module scipyintegrate has no attribute trapz

### DIFF
--- a/canflood/build/dialog.py
+++ b/canflood/build/dialog.py
@@ -1551,9 +1551,11 @@ class BuildDialog(QtWidgets.QDialog, FORM_CLASS, hlpr.plug.QprojPlug):
         #=======================================================================
         self.feedback.upd_prog(100)
         
-        log.push(f'passed %i (of %i) validations. see log for errors: {QgsLogger.logFile()}'%(
-             np.array(list(res_d.values())).sum(), len(vpars_d)
-             ))
+        log.push('passed %i (of %i) validations. see log for errors: %s' % (
+            np.array(list(res_d.values())).sum(), 
+            len(vpars_d), 
+            QgsLogger.logFile()
+            ))
         
         self.feedback.upd_prog(None)
         self.validation_result_d=validation_result_d #store for ttests

--- a/canflood/model/riskcom.py
+++ b/canflood/model/riskcom.py
@@ -13,7 +13,7 @@ from scipy import interpolate, integrate
 from hlpr.exceptions import QError as Error
 from hlpr.plot import Plotr, view
 from model.modcom import Model
-
+import scipy
 
 class RiskModel(Plotr, Model): #common methods for risk1 and risk2
     
@@ -1107,11 +1107,27 @@ class RiskModel(Plotr, Model): #common methods for risk1 and risk2
         # 
         #======================================================================
         if self.integrate == 'trapz':
-        
-            ead_tot = integrate.trapz(
+            try:
+                ead_tot = integrate.trapezoid(
                 y, #yaxis - aeps
                 x=x, #xaxis = damages 
                 dx = dx)
+            except AttributeError:
+                try:
+                    # Fall back to the older `trapz` method if `trapezoid` is not available
+                    ead_tot = integrate.trapz(
+                        y,  # y-axis (e.g., aeps)
+                        x=x,  # x-axis (e.g., damages)
+                        dx=dx  # Spacing between points
+                        )
+                
+                except AttributeError:
+                    # Handle the case where neither method is available
+                    scipy_version =  scipy.__version__
+                    raise RuntimeError(
+                        f"Integration failed. Ensure you have a compatible SciPy version. "
+                        f"Detected SciPy version: {scipy_version}."
+                        )
             
         elif self.integrate == 'simps':
             self.logger.warning('integration method not tested')

--- a/tests2/modelt/test_riskcom.py
+++ b/tests2/modelt/test_riskcom.py
@@ -1,100 +1,27 @@
 import pytest
-import numpy as np
-from scipy import integrate
-from unittest.mock import MagicMock, patch
 import pandas as pd
+import numpy as np
+from model.riskcom import RiskModel
 
-class Plotr:
-    pass
-
-class Model:
-    pass
-
-class RiskModel(Plotr, Model):
-    def __init__(self, integrate_method="trapz", precision=2):
-        self.integrate = integrate_method
-        self.prec = precision
-        self.logger = MagicMock()  
-        
-    def _get_ev(self, ser, dx=0.1):
-        """
-        Calculate the integration using the specified method.
-        """
-        x = ser.tolist()  # Impacts
-        y = ser.index.values.round(self.prec + 2).tolist()  # AEPs
-
-        if self.integrate == "trapz":
-            try:
-                ead_tot = integrate.trapezoid(y, x=x, dx=dx)
-            except AttributeError:
-                try:
-                    ead_tot = integrate.trapz(y, x=x, dx=dx)
-                except AttributeError:
-                    raise RuntimeError(
-                        f"Integration failed. Ensure you have a compatible SciPy version."
-                    )
-
-        elif self.integrate == "simps":
-            self.logger.warning("Integration method not tested")
-            ead_tot = integrate.simps(y, x=x, dx=dx)
-
-        else:
-            raise ValueError(f"Integration method '{self.integrate}' not recognized")
-
-        return round(ead_tot, self.prec)
-    
-# Fixtures for testing
 @pytest.fixture
 def risk_model():
-    """Fixture to initialize the RiskModel class."""
-    return RiskModel(integrate_method="trapz", precision=2)
+    """Fixture to create a RiskModel instance with necessary attributes."""
+    model = RiskModel()
+    model.prec = 2  # Set precision for rounding
+    model.integrate = 'trapz'  # Integration method
+    return model
 
-@pytest.fixture
-def test_series():
-    """Fixture to provide a sample Pandas Series."""
-    data = [0.1, 0.2, 0.3, 0.4, 0.5]
-    index = [1, 2, 3, 4, 5]  # Example AEPs
-    return pd.Series(data, index=index)
-
-# Test cases
-def test_get_ev_trapezoid(risk_model, test_series):
-    """Test _get_ev with the trapezoid method."""
-    risk_model.integrate = "trapz"
-    result = risk_model._get_ev(test_series, dx=0.1)
-    expected = integrate.trapezoid(
-        test_series.index.values.tolist(),
-        x=test_series.tolist(),
-        dx=0.1
-    )
-    assert result == round(expected, risk_model.prec)
+def test_get_ev_simple(risk_model):
+    """Test _get_ev with a simple dataset."""
+    # Input data
+    aep_values = [0.1, 0.05, 0.01]
+    damage_values = [1000, 5000, 10000]
+    ser = pd.Series(data=damage_values, index=aep_values)
     
-def test_get_ev_simps(risk_model, test_series):
-    """Test _get_ev with the simps method."""
-    risk_model.integrate = "simps"
-    result = risk_model._get_ev(test_series, dx=0.1)
-    expected = integrate.simps(
-        test_series.index.values.tolist(),
-        x=test_series.tolist(),
-        dx=0.1
-    )
-    assert result == round(expected, risk_model.prec)
-
-def test_get_ev_invalid_method(risk_model, test_series):
-    """Test _get_ev with an invalid integration method."""
-    risk_model.integrate = "invalid_method"
-    with pytest.raises(ValueError, match="Integration method 'invalid_method' not recognized"):
-        risk_model._get_ev(test_series)
-
-def test_get_ev_trapz_fallback(risk_model, test_series):
-    """Test _get_ev when falling back to trapz."""
-    risk_model.integrate = "trapz"
-    with patch("scipy.integrate.trapezoid", side_effect=AttributeError):
-        result = risk_model._get_ev(test_series, dx=0.1)
-        expected = integrate.trapz(
-            test_series.index.values.tolist(),
-            x=test_series.tolist(),
-            dx=0.1
-        )
-        assert result == round(expected, risk_model.prec)
-
-        
+   
+    expected_ev = 450.0  
+    
+    result = risk_model._get_ev(ser, dx=0.1)
+    
+    # Assertion
+    assert np.isclose(result, expected_ev, atol=1e-2), f"Expected {expected_ev}, got {result}"

--- a/tests2/modelt/test_riskcom.py
+++ b/tests2/modelt/test_riskcom.py
@@ -1,27 +1,50 @@
 import pytest
 import pandas as pd
 import numpy as np
+import logging
 from model.riskcom import RiskModel
 
-@pytest.fixture
+# Test cases for parameterization
+test_cases = {
+    "simple_case": {
+        "aep_values": [0.1, 0.05, 0.01],
+        "damage_values": [1000, 5000, 10000],
+        "dx": 0.1,
+        "expected_ev": 450.0,
+    },
+}
+
+@pytest.fixture(scope="function")
 def risk_model():
-    """Fixture to create a RiskModel instance with necessary attributes."""
+    """Fixture to create a properly initialized RiskModel instance."""
     model = RiskModel()
-    model.prec = 2  # Set precision for rounding
-    model.integrate = 'trapz'  # Integration method
+    model.prec = 2  # Precision for rounding
+    model.integrate = "trapz"  # Integration method
+    model.data_d = {}  # Mock data dictionary
+    model.logger = logging.getLogger("RiskModel")  # Attach a logger
     return model
 
-def test_get_ev_simple(risk_model):
-    """Test _get_ev with a simple dataset."""
+@pytest.fixture(scope="function")
+def test_data(request):
+    """Fixture to retrieve test-specific data."""
+    return test_cases[request.param]
+
+@pytest.mark.parametrize(
+    "test_data", ["simple_case"], indirect=True  
+)
+def test_get_ev_with_parameters(risk_model, test_data):
+    """Test _get_ev with parameterized inputs."""
+    # Extract parameters from the test data
+    aep_values = test_data["aep_values"]
+    damage_values = test_data["damage_values"]
+    dx = test_data["dx"]
+    expected_ev = test_data["expected_ev"]
+
     # Input data
-    aep_values = [0.1, 0.05, 0.01]
-    damage_values = [1000, 5000, 10000]
     ser = pd.Series(data=damage_values, index=aep_values)
+
     
-   
-    expected_ev = 450.0  
-    
-    result = risk_model._get_ev(ser, dx=0.1)
-    
+    result = risk_model._get_ev(ser, dx=dx)
+
     # Assertion
     assert np.isclose(result, expected_ev, atol=1e-2), f"Expected {expected_ev}, got {result}"

--- a/tests2/modelt/test_riskcom.py
+++ b/tests2/modelt/test_riskcom.py
@@ -1,0 +1,100 @@
+import pytest
+import numpy as np
+from scipy import integrate
+from unittest.mock import MagicMock, patch
+import pandas as pd
+
+class Plotr:
+    pass
+
+class Model:
+    pass
+
+class RiskModel(Plotr, Model):
+    def __init__(self, integrate_method="trapz", precision=2):
+        self.integrate = integrate_method
+        self.prec = precision
+        self.logger = MagicMock()  
+        
+    def _get_ev(self, ser, dx=0.1):
+        """
+        Calculate the integration using the specified method.
+        """
+        x = ser.tolist()  # Impacts
+        y = ser.index.values.round(self.prec + 2).tolist()  # AEPs
+
+        if self.integrate == "trapz":
+            try:
+                ead_tot = integrate.trapezoid(y, x=x, dx=dx)
+            except AttributeError:
+                try:
+                    ead_tot = integrate.trapz(y, x=x, dx=dx)
+                except AttributeError:
+                    raise RuntimeError(
+                        f"Integration failed. Ensure you have a compatible SciPy version."
+                    )
+
+        elif self.integrate == "simps":
+            self.logger.warning("Integration method not tested")
+            ead_tot = integrate.simps(y, x=x, dx=dx)
+
+        else:
+            raise ValueError(f"Integration method '{self.integrate}' not recognized")
+
+        return round(ead_tot, self.prec)
+    
+# Fixtures for testing
+@pytest.fixture
+def risk_model():
+    """Fixture to initialize the RiskModel class."""
+    return RiskModel(integrate_method="trapz", precision=2)
+
+@pytest.fixture
+def test_series():
+    """Fixture to provide a sample Pandas Series."""
+    data = [0.1, 0.2, 0.3, 0.4, 0.5]
+    index = [1, 2, 3, 4, 5]  # Example AEPs
+    return pd.Series(data, index=index)
+
+# Test cases
+def test_get_ev_trapezoid(risk_model, test_series):
+    """Test _get_ev with the trapezoid method."""
+    risk_model.integrate = "trapz"
+    result = risk_model._get_ev(test_series, dx=0.1)
+    expected = integrate.trapezoid(
+        test_series.index.values.tolist(),
+        x=test_series.tolist(),
+        dx=0.1
+    )
+    assert result == round(expected, risk_model.prec)
+    
+def test_get_ev_simps(risk_model, test_series):
+    """Test _get_ev with the simps method."""
+    risk_model.integrate = "simps"
+    result = risk_model._get_ev(test_series, dx=0.1)
+    expected = integrate.simps(
+        test_series.index.values.tolist(),
+        x=test_series.tolist(),
+        dx=0.1
+    )
+    assert result == round(expected, risk_model.prec)
+
+def test_get_ev_invalid_method(risk_model, test_series):
+    """Test _get_ev with an invalid integration method."""
+    risk_model.integrate = "invalid_method"
+    with pytest.raises(ValueError, match="Integration method 'invalid_method' not recognized"):
+        risk_model._get_ev(test_series)
+
+def test_get_ev_trapz_fallback(risk_model, test_series):
+    """Test _get_ev when falling back to trapz."""
+    risk_model.integrate = "trapz"
+    with patch("scipy.integrate.trapezoid", side_effect=AttributeError):
+        result = risk_model._get_ev(test_series, dx=0.1)
+        expected = integrate.trapz(
+            test_series.index.values.tolist(),
+            x=test_series.tolist(),
+            dx=0.1
+        )
+        assert result == round(expected, risk_model.prec)
+
+        

--- a/tests2/modelt/test_riskcom.py
+++ b/tests2/modelt/test_riskcom.py
@@ -15,14 +15,14 @@ test_cases = {
 }
 
 @pytest.fixture(scope="function")
-def risk_model():
-    """Fixture to create a properly initialized RiskModel instance."""
-    model = RiskModel()
-    model.prec = 2  # Precision for rounding
-    model.integrate = "trapz"  # Integration method
-    model.data_d = {}  # Mock data dictionary
-    model.logger = logging.getLogger("RiskModel")  # Attach a logger
-    return model
+def risk_model(logger, test_name):
+    with RiskModel(  
+        logger=logging.getLogger("RiskModel"),
+        tag=test_name, 
+        overwrite=True          
+    ) as model:
+        yield model 
+
 
 @pytest.fixture(scope="function")
 def test_data(request):
@@ -43,7 +43,6 @@ def test_get_ev_with_parameters(risk_model, test_data):
     # Input data
     ser = pd.Series(data=damage_values, index=aep_values)
 
-    
     result = risk_model._get_ev(ser, dx=dx)
 
     # Assertion


### PR DESCRIPTION
-Fixed the string format error, which occurred after build setup  
- Added support and backward compatibility for Trapz.
- Wrapped code with try error block and raised appropriate error.
- Created a test for the _get_eval and covered different scenarios. 